### PR TITLE
Adding PSD 2 hint for Credit Card payment method in Opencart

### DIFF
--- a/admin/language/de-de/extension/payment/wirecard_pg_creditcard.php
+++ b/admin/language/de-de/extension/payment/wirecard_pg_creditcard.php
@@ -29,6 +29,8 @@ $_['config_vault'] = "One-Click Checkout";
 $_['config_vault_desc'] = "Kreditkarten können gespeichert und später wieder verwendet werden.";
 $_['config_allow_changed_shipping'] = "Geänderte Lieferadresse zulassen";
 $_['config_allow_changed_shipping_desc'] = "Wenn diese Option deaktiviert ist und sich die Lieferadresse des Kunden zwischen Transaktionen ändert, müssen sie ihre Kreditkarteninformationen erneut eingeben.";
+$_['config_psd_two_heading'] = 'PSD 2';
+$_['config_psd_two_text'] = 'Angesichts der Bestimmungen der PSD 2 sollten Sie beim <a href="https://github.com/wirecard/opencart-ee/wiki/Credit-Card" target="_blank">Checkout</a> bestimmte persönliche Daten von Ihren Kunden anfordern, um das Risiko, dass Transaktionen abgelehnt werden, zu reduzieren.';
 
 $_['config_challenge_indicator'] = 'Challenge Indicator';
 $_['config_challenge_indicator_desc'] = 'Indicates whether a challenge is requested for this transaction.';

--- a/admin/language/en-gb/extension/payment/wirecard_pg_creditcard.php
+++ b/admin/language/en-gb/extension/payment/wirecard_pg_creditcard.php
@@ -28,6 +28,8 @@ $_['config_vault'] = "One-Click Checkout";
 $_['config_vault_desc'] = "Credit Card details are saved for later use.";
 $_['config_allow_changed_shipping'] = "Allow Shipping Address Change";
 $_['config_allow_changed_shipping_desc'] = "If disabled, consumer is required to re-enter credit card details if the shipping address has changed between two orders.";
+$_['config_psd_two_heading'] = 'PSD 2';
+$_['config_psd_two_text'] = 'With regards to PSD2 requirements, you should request certain personal information from your consumers during <a href="https://github.com/wirecard/opencart-ee/wiki/Credit-Card" target="_blank">checkout</a> to reduce the risk of transactions being rejected.';
 
 $_['config_challenge_indicator'] = 'Challenge Indicator';
 $_['config_challenge_indicator_desc'] = 'Indicates whether a challenge is requested for this transaction.';

--- a/admin/view/template/extension/payment/wirecard_pg/basic_config.twig
+++ b/admin/view/template/extension/payment/wirecard_pg/basic_config.twig
@@ -39,6 +39,12 @@
         </div>
     {% endfor %}
 {% endif %}
+<div class="form-group">
+    <label class="col-sm-2 text-right" for="psd-two-link">{{ config_psd_two_heading }}</label>
+    <div class="col-sm-10 description">
+        <i>{{ config_psd_two_text }}</i>
+    </div>
+</div>
 {% if type != 'sepact' %}
     <div class="form-group required">
         <label class="col-sm-2 control-label" for="input-sort-order">{{ config_sort_order }}</label>


### PR DESCRIPTION
Signed-off-by: Ana Albic <ana.albic@comtrade.com>

In this PR, PSD 2 hint is added into Credit Card payment method panel in admin, below the Title section.
Hint contains a link to Credit Card page on GitHub, which is opened in an additional tab in the browser.
Hint is translatable to German and English languages. For other languages, English version is set by default.