### PR TITLE
Showed order number with disabled additional info in Opencart transaction

### DIFF
--- a/catalog/controller/extension/payment/wirecard_pg/gateway.php
+++ b/catalog/controller/extension/payment/wirecard_pg/gateway.php
@@ -160,6 +160,7 @@ abstract class ControllerExtensionPaymentGateway extends Controller {
 		$this->transaction->setRedirect($this->getRedirects($this->session->data['order_id']));
 		$this->transaction->setNotificationUrl($this->getNotificationUrl());
 		$this->transaction->setAmount($amount);
+		$this->transaction->setOrderNumber($order['order_id']);
 
 		$this->transaction = $additional_helper->setIdentificationData($this->transaction, $order);
 		if ($this->getShopConfigVal('descriptor')) {

--- a/catalog/model/extension/payment/wirecard_pg/helper/additional_information_helper.php
+++ b/catalog/model/extension/payment/wirecard_pg/helper/additional_information_helper.php
@@ -140,7 +140,6 @@ class AdditionalInformationHelper extends Model {
 		if (strlen($order['customer_id'])) {
 			$transaction->setConsumerId($order['customer_id']);
 		}
-		$transaction->setOrderNumber($order['order_id']);
 		$transaction->setDescriptor($this->createDescriptor($order));
 		$transaction = $this->addAccountHolder($transaction, $order);
 


### PR DESCRIPTION
Signed-off-by: Ana Albic <ana.albic@comtrade.com>

The order number is shown in the Opencart in transaction detail panel. The order number is visible if additional information are set to _Disable_.