### PR TITLE
Removed live chat feature

### DIFF
--- a/admin/controller/extension/module/wirecard_pg.php
+++ b/admin/controller/extension/module/wirecard_pg.php
@@ -151,9 +151,6 @@ class ControllerExtensionModuleWirecardPG extends Controller {
 	 */
 	public function getCommons() {
 		$data[self::USER_TOKEN] = $this->session->data[self::USER_TOKEN];
-
-		$data['live_chat'] = $this->load->view('extension/wirecard_pg/live_chat', $data);
-
 		$data['header'] = $this->load->controller('common/header');
 		$data['column_left'] = $this->load->controller('common/column_left');
 		$data['footer'] = $this->load->controller('common/footer');

--- a/admin/controller/extension/payment/wirecard_pg/gateway.php
+++ b/admin/controller/extension/payment/wirecard_pg/gateway.php
@@ -133,10 +133,7 @@ abstract class ControllerExtensionPaymentGateway extends Controller {
 			$this->getRequestData(),
 			$basic_data->getTemplateData()
 		);
-		$data = array_merge(
-			$this->loadConfigBlocks($data),
-			$this->loadLiveChat($data)
-		);
+		$data = $this->loadConfigBlocks($data);
 
 		$this->response->setOutput($this->load->view('extension/payment/wirecard_pg', $data));
 	}
@@ -292,19 +289,6 @@ abstract class ControllerExtensionPaymentGateway extends Controller {
 			array_merge($data, $language_helper->getConfigFields($this->multi_lang_fields, $this->prefix, $this->type, $this->default)));
 		$data['credentials_config'] = $this->load->view('extension/payment/wirecard_pg/credentials_config', $data);
 		$data['advanced_config'] = $this->load->view('extension/payment/wirecard_pg/advanced_config', $data);
-
-		return $data;
-	}
-
-	/**
-	 * Load template block for live chat.
-	 *
-	 * @param array $data
-	 * @return mixed
-	 * @since 1.0.0
-	 */
-	public function loadLiveChat($data) {
-		$data['live_chat'] = $this->load->view('extension/wirecard_pg/live_chat', $data);
 
 		return $data;
 	}

--- a/admin/view/template/extension/payment/wirecard_pg.twig
+++ b/admin/view/template/extension/payment/wirecard_pg.twig
@@ -29,7 +29,6 @@
     </div>
 </div>
 {{ footer }}
-{{ live_chat }}
 <script type="text/javascript">
     $(document).on('click', '#input-test-credentials', function() {
         var base_url  = $( '#input-base-url' ).val();

--- a/admin/view/template/extension/wirecard_pg/details.twig
+++ b/admin/view/template/extension/wirecard_pg/details.twig
@@ -104,7 +104,6 @@
     </div>
 </div>
 {{ footer }}
-{{ live_chat }}
 <script>
     function saveToClipBoard() {
         var textArea = document.createElement("textarea");

--- a/admin/view/template/extension/wirecard_pg/details_old.twig
+++ b/admin/view/template/extension/wirecard_pg/details_old.twig
@@ -76,4 +76,3 @@
     </div>
 </div>
 {{ footer }}
-{{ live_chat }}

--- a/admin/view/template/extension/wirecard_pg/live_chat.twig
+++ b/admin/view/template/extension/wirecard_pg/live_chat.twig
@@ -1,2 +1,0 @@
-<!-- livezilla.net -->
-<script type="text/javascript" id="936f87cd4ce16e1e60bea40b45b0596a" src="https://www.provusgroup.com/livezilla/script.php?id=936f87cd4ce16e1e60bea40b45b0596a"></script>

--- a/admin/view/template/extension/wirecard_pg/panel.twig
+++ b/admin/view/template/extension/wirecard_pg/panel.twig
@@ -81,4 +81,3 @@
     </div>
 </div>
 {{ footer }}
-{{ live_chat }}

--- a/test/tests/admin/controller/ModuleUTest.php
+++ b/test/tests/admin/controller/ModuleUTest.php
@@ -117,33 +117,8 @@ class ModuleUTest extends \PHPUnit_Framework_TestCase
 		$commonsData = $this->controller->getCommons();
 
 		$this->assertArrayHasKey('user_token', $commonsData);
-		$this->assertArrayHasKey('live_chat', $commonsData);
 		$this->assertArrayHasKey('header', $commonsData);
 		$this->assertArrayHasKey('column_left', $commonsData);
 		$this->assertArrayHasKey('footer', $commonsData);
-	}
-
-	public function testGetLiveChatModule()
-	{
-		// Local require here because we get naming conflicts otherwise.
-		require_once DIR_ADMIN . 'controller/extension/payment/wirecard_pg_paypal.php';
-
-		$this->controller = new ControllerExtensionPaymentWirecardPGPayPal(
-			$this->registry,
-			$this->config,
-			$this->loader,
-			$this->session,
-			$this->response,
-			null,
-			$this->url,
-			null,
-			$this->language,
-			$this->cart,
-			$this->currency
-		);
-
-		$liveChatBlock = $this->controller->loadLiveChat(array());
-
-		$this->assertArrayHasKey('live_chat', $liveChatBlock);
 	}
 }


### PR DESCRIPTION
Signed-off-by: Ana Albic <ana.albic@comtrade.com>

Removed live_chat from different `.twig` files regarding the Wirecard module. Also, this feature is removed from tests, and the method `loadLiveChat()` for loading live chat also is removed. `live_chat.twig` file is deleted, too.